### PR TITLE
No missing md extension

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,24 +8,35 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [8.x, 10.x, 11.x]
+        node-version: [8, 10, 11]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Git Source
+      uses: actions/checkout@v2
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g npminstall && npminstall
-    - run: npm run ci
-      env:
-        CI: true
+
+    - name: Install Dependencies
+      run: npm i -g npminstall && npminstall
+
+    - name: Continuous Integration
+      run: npm run ci
+
+    - name: Code Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,35 +8,24 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  schedule:
-    - cron: '0 2 * * *'
 
 jobs:
   build:
+
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false
       matrix:
-        node-version: [8, 10, 11]
+        node-version: [8.x, 10.x, 11.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - name: Checkout Git Source
-      uses: actions/checkout@v2
-
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Install Dependencies
-      run: npm i -g npminstall && npminstall
-
-    - name: Continuous Integration
-      run: npm run ci
-
-    - name: Code Coverage
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+    - run: npm i -g npminstall && npminstall
+    - run: npm run ci
+      env:
+        CI: true

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options:
   -i, --ignore [pattern]   Ignore patterns, will merge to pattern, default to **/node_modules
   --exit-level [level]     Process exit level, default to error, other choice is warn and none, it will not exit if setting to none
   --default-index [index]  Default index in directory, default to README.md,readme.md
+  --strict-ext             Enables strict extension mode. Where a link to an md file must have the .md extension
   -h, --help               output usage information
 ```
 

--- a/bin.js
+++ b/bin.js
@@ -16,7 +16,8 @@ const program = new Command()
   .option('-i, --ignore [pattern]', `Ignore patterns, will merge to pattern, default to ${presetConfig.default.ignore.join(',')}`)
   .option('--ignore-footnotes', `Ignore footnotes, default to ${presetConfig.default.ignoreFootnotes}`)
   .option('--exit-level [level]', `Process exit level, default to ${presetConfig.default.exitLevel}, other choice is warn and none, it will not exit if setting to none`)
-  .option('--default-index [index]', `Default index in directory, default to ${presetConfig.default.defaultIndex.join(',')}`);
+  .option('--default-index [index]', `Default index in directory, default to ${presetConfig.default.defaultIndex.join(',')}`)
+  .option('--strict-ext', 'Enables strict extension mode. Where a link to an md file must have the .md extension');
 
 program.parse(process.argv);
 
@@ -29,6 +30,7 @@ const options = {
   ignore: program.ignore ? program.ignore.split(',') : undefined,
   ignoreFootnotes: program.ignoreFootnotes,
   defaultIndex: program.defaultIndex ? program.defaultIndex.split(',') : undefined,
+  strictExt: program.strictExt ? program.strictExt : undefined,
 };
 
 Object.keys(options).forEach(k => {
@@ -41,5 +43,6 @@ if (packageInfo['check-md']) {
   // read from package.json
   Object.assign(options, packageInfo['check-md']);
 }
+console.log({ options });
 
 checkAndThrow(options);

--- a/bin.js
+++ b/bin.js
@@ -43,6 +43,5 @@ if (packageInfo['check-md']) {
   // read from package.json
   Object.assign(options, packageInfo['check-md']);
 }
-console.log({ options });
 
 checkAndThrow(options);

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@
 export interface CheckOption {
   cwd: string;
   fix?: boolean;
+  strictExt?: boolean;
   exitLevel?: "none" | "info" | "warn" | "error";
   root?: string[];
   defaultIndex?: string[];

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ const presetConfig = {
  * @property {String | Array<String>} [CheckOption.pattern]
  * @property {String | Array<String>} [CheckOption.ignore]
  * @property {Boolean} [CheckOption.ignoreFootnotes]
+ * @property {Boolean} [CheckOption.strictExt]
  */
 
 /**
@@ -219,7 +220,7 @@ function initOption(options) {
  */
 async function check(options) {
   options = initOption(options);
-  const { cwd, defaultIndex, root, fix, pattern, ignore, ignoreFootnotes } = options;
+  const { cwd, defaultIndex, root, fix, pattern, ignore, ignoreFootnotes, strictExt } = options;
   assert(Array.isArray(root), 'options.root must be array');
   const globPattern = (Array.isArray(pattern) ? pattern : [ pattern ]).concat(
     (Array.isArray(ignore) ? ignore : [ ignore ]).map(p => `!${p}`)
@@ -324,7 +325,7 @@ async function check(options) {
             }
           }
           // md file should always have .md extension to not confused with any other type of file
-          if (ext === '') {
+          if (ext === '' && strictExt) {
             const dirBaseFileWithSlash = `${urlObj.path}/README.md`.slice(1);
             const dirBaseFile = `${urlObj.path}README.md`.slice(1);
             // Check if missing extension link is a directory with a base README.md file

--- a/index.js
+++ b/index.js
@@ -331,6 +331,7 @@ async function check(options) {
             // Check if missing extension link is a directory with a base README.md file
             if (!(files.includes(dirBaseFileWithSlash) || files.includes(dirBaseFile))) {
               const fileWithMDext = `${urlObj.path}.md`.slice(1);
+              // Check if missing extension link is a known markdown file.
               if (files.includes(fileWithMDext)) {
                 result.warning.list.push({ ...baseReportObj, errMsg: 'File found with this name but .md extension missing' });
               }

--- a/index.js
+++ b/index.js
@@ -323,6 +323,18 @@ async function check(options) {
               result.warning.list.push({ ...baseReportObj, errMsg: 'Should use .md instead of .html' });
             }
           }
+          // md file should always have .md extension to not confused with any other type of file
+          if (ext === '') {
+            const dirBaseFileWithSlash = `${urlObj.path}/README.md`.slice(1);
+            const dirBaseFile = `${urlObj.path}README.md`.slice(1);
+            // Check if missing extension link is a directory with a base README.md file
+            if (!(files.includes(dirBaseFileWithSlash) || files.includes(dirBaseFile))) {
+              const fileWithMDext = `${urlObj.path}.md`.slice(1);
+              if (files.includes(fileWithMDext)) {
+                result.warning.list.push({ ...baseReportObj, errMsg: 'File found with this name but .md extension missing' });
+              }
+            }
+          }
 
           if (!matchAbUrl || !fileExist(matchAbUrl)) {
             // file is not found

--- a/package.json
+++ b/package.json
@@ -6,21 +6,21 @@
     "check-md": "./bin.js"
   },
   "dependencies": {
-    "@sindresorhus/slugify": "^0.8.0",
-    "chalk": "^2.4.2",
-    "commander": "^2.19.0",
+    "chalk": "^4.0.0",
+    "commander": "^5.0.0",
     "diacritics": "^1.3.0",
-    "globby": "^9.1.0"
+    "globby": "^11.0.0"
   },
   "devDependencies": {
-    "autod": "^3.0.1",
-    "coffee": "^5.2.1",
-    "egg-bin": "^4.3.7",
-    "egg-ci": "^1.8.0",
-    "egg-mock": "^3.21.0",
-    "eslint": "^4.18.1",
-    "eslint-config-egg": "^7.0.0",
-    "js2dts": "^0.3.0"
+    "autod": "^3.1.0",
+    "coffee": "^5.2.2",
+    "egg-bin": "^4.14.1",
+    "egg-ci": "^1.14.0",
+    "egg-mock": "^4.0.0",
+    "eslint": "^6.8.0",
+    "eslint-config-egg": "^8.0.1",
+    "js2dts": "^0.3.0",
+    "webstorm-disable-index": "^1.2.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/test/fixtures/docs1/test.md
+++ b/test/fixtures/docs1/test.md
@@ -41,3 +41,5 @@ asdasd11123 ```[test15](./123.md#ctx.get(name))```
 Footnotes[^test17] test ref
 
 [^test17]: Footnote description
+[test17](/dir)
+[test18](/dir#test)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ describe('test/index.test.js', () => {
 
   it('should works without error', async () => {
     const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1') });
-    assert(result.deadlink.list.length === 5);
+    assert(result.deadlink.list.length === 6);
     assert(result.warning.list.length === 1);
     assert(result.deadlink.list[0].fullText.includes('[test1]'));
     assert(result.deadlink.list[0].line === 5);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,9 +8,9 @@ describe('test/index.test.js', () => {
   afterEach(mm.restore);
 
   it('should works without error', async () => {
-    const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1') });
+    const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1'), strictExt: true });
     assert(result.deadlink.list.length === 6);
-    assert(result.warning.list.length === 1);
+    assert(result.warning.list.length === 3);
     assert(result.deadlink.list[0].fullText.includes('[test1]'));
     assert(result.deadlink.list[0].line === 5);
     assert(result.deadlink.list[0].col === 5);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,44 @@ describe('test/index.test.js', () => {
   afterEach(mm.restore);
 
   it('should works without error', async () => {
+    const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1') });
+    assert(result.deadlink.list.length === 5);
+    assert(result.warning.list.length === 1);
+    assert(result.deadlink.list[0].fullText.includes('[test1]'));
+    assert(result.deadlink.list[0].line === 5);
+    assert(result.deadlink.list[0].col === 5);
+    assert(result.deadlink.list[1].fullText.includes('[test8]'));
+    assert(result.deadlink.list[1].line === 19);
+    assert(result.deadlink.list[1].col === 1);
+    assert(result.deadlink.list[2].fullText.includes('[test9]'));
+    assert(result.deadlink.list[2].line === 21);
+    assert(result.deadlink.list[2].col === 13);
+    assert(result.deadlink.list[3].fullText.includes('[test12]'));
+    assert(result.deadlink.list[4].fullText.includes('[test16]'));
+    assert(result.deadlink.list[3].errMsg.includes('slugify'));
+    assert(result.warning.list[0].fullText.includes('[test6]'));
+  });
+
+  it('should works without error in strict mode', async () => {
+    const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1'), strictExt: true });
+    assert(result.deadlink.list.length === 6);
+    assert(result.warning.list.length === 3);
+    assert(result.deadlink.list[0].fullText.includes('[test1]'));
+    assert(result.deadlink.list[0].line === 5);
+    assert(result.deadlink.list[0].col === 5);
+    assert(result.deadlink.list[1].fullText.includes('[test8]'));
+    assert(result.deadlink.list[1].line === 19);
+    assert(result.deadlink.list[1].col === 1);
+    assert(result.deadlink.list[2].fullText.includes('[test9]'));
+    assert(result.deadlink.list[2].line === 21);
+    assert(result.deadlink.list[2].col === 13);
+    assert(result.deadlink.list[3].fullText.includes('[test12]'));
+    assert(result.deadlink.list[4].fullText.includes('[test16]'));
+    assert(result.deadlink.list[3].errMsg.includes('slugify'));
+    assert(result.warning.list[0].fullText.includes('[test6]'));
+  });
+
+  it('should works without error in strict mode', async () => {
     const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1'), strictExt: true });
     assert(result.deadlink.list.length === 6);
     assert(result.warning.list.length === 3);


### PR DESCRIPTION
# New in this PR
This is a PR that does the following: 

- Upgrading packages
- Added `strict extension` mode in the options. 

## Strict Extension Mode

The strict extension mode makes the .md extension mandatory in links to recognized md files. 

This means that a link to a markdown file not containing the .md extension will raise a warning: 

<img width="1113" alt="Screenshot 2020-04-11 at 14 54 54" src="https://user-images.githubusercontent.com/33010418/79044266-6ede5780-7c04-11ea-8913-694aff625505.png">

This only raises an error when the .md extension is missing on a md file. If the link is to a directory because it will automatically redirect to the `README.md` or `index.md` file inside that directory, it will NOT raise a warning.

Since `dir` is a directory containing a README.md file, this will **NOT raise an error**:
```
[test17](/dir)
[test18](/dir#test)
```

Since `other` is a markdown file whose .md extension is missing, this **will raise an error**: 
```
[test7](/other#ctx-get-name)

[test8](/other#cccc)
```

```bash
Checking markdown...

2 warning was found
 
File found with this name but .md extension missing: [test7](/other#ctx-get-name) (/Users/charlottevermandel/check-md/test/fixtures/docs1/test.md:17:1)
File found with this name but .md extension missing: [test8](/other#cccc) (/Users/charlottevermandel/check-md/test/fixtures/docs1/test.md:19:1)
```
### Usage

it is used, as --fix, by adding the option without parameter.
```
check-md -p 'vuepress' -c 'test/fixtures/vuepress' --strict-ext
```

### Implementation

It has been added in the CLI and in the options. I did not add it in any preset as I don't think most people would want this by default.

Tests have been added and it has been added in the typescript declaration file.

